### PR TITLE
Fix deleted function compilation issue (likely Qt6 related)

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -211,7 +211,7 @@ bool MainWindow::loadFont()
     memcpy(marker, ibmfPreamble->marker, 4);
     marker[4] = 0;
 
-    putValue(ui->fontHeader, 0, 1, marker,                       false);
+    putValue(ui->fontHeader, 0, 1, QByteArray(marker),                       false);
     putValue(ui->fontHeader, 1, 1, ibmfPreamble->face_count,    false);
     putValue(ui->fontHeader, 2, 1, ibmfPreamble->bits.version,  false);
     putValue(ui->fontHeader, 3, 1, ibmfPreamble->bits.char_set, false);


### PR DESCRIPTION
My compilation was failing with
```
(base)  ~/Developer/repos/turgu1/IBMF-Font-Editor/build   main  make
[ 16%] Automatic MOC and UIC for target IBMFFontEditor
[ 16%] Built target IBMFFontEditor_autogen
[ 33%] Building CXX object CMakeFiles/IBMFFontEditor.dir/IBMFFontEditor_autogen/mocs_compilation.cpp.o
[ 50%] Building CXX object CMakeFiles/IBMFFontEditor.dir/main.cpp.o
[ 66%] Building CXX object CMakeFiles/IBMFFontEditor.dir/mainwindow.cpp.o
/Users/johnboiles/Developer/repos/turgu1/IBMF-Font-Editor/mainwindow.cpp:214:36: error: conversion function from 'char[5]' to 'QVariant' invokes a deleted function
    putValue(ui->fontHeader, 0, 1, marker,                       false);
                                   ^~~~~~
/opt/homebrew/lib/QtCore.framework/Headers/qvariant.h:199:5: note: 'QVariant<char *, false>' has been explicitly marked deleted here
    QVariant(T) = delete;
    ^
/Users/johnboiles/Developer/repos/turgu1/IBMF-Font-Editor/mainwindow.cpp:176:72: note: passing argument to parameter 'value' here
void MainWindow::putValue(QTableWidget * w, int row, int col, QVariant value, bool editable)
                                                                       ^
1 error generated.
make[2]: *** [CMakeFiles/IBMFFontEditor.dir/mainwindow.cpp.o] Error 1
make[1]: *** [CMakeFiles/IBMFFontEditor.dir/all] Error 2
make: *** [all] Error 2
```

Reading through [this issue](https://github.com/Stellarium/stellarium/issues/2709) it seems that it might be a Qt6 thing.

Sure enough `brew info qt` gives shows I'm on `qt: stable 6.4.2`.